### PR TITLE
Add a link to the new hamachi-setup wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,10 @@ coworkers with one half of an ongoing conversation.
 ## VPN
 
 LogMeIn's [Hamachi](https://secure.logmein.com/products/hamachi/) is a reliable
-way of creating ad-hoc VPNs, but it's a bit annoying to admin.
+way of creating ad-hoc VPNs, but it's a bit annoying to admin. The set up
+process is described in this
+[wiki page](https://github.com/livingsocial/ls-pair/wiki/How-to-set-up-LogMeIn-Hamachi).
+
 
 ## SSH
 


### PR DESCRIPTION
While trying to pair today, we spent a good deal of time trying to figure out how to set Hamachi up.

I added a [new wiki](https://github.com/livingsocial/ls-pair/wiki/How-to-set-up-LogMeIn-Hamachi) to this repo. This change adds a link to that wiki from the `README`.
