### PR TITLE
Fix errors in provided tmux.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vimconfig/vim/.netrwhist
+public_keys/*.pub

--- a/bin/create_all_pair_accounts
+++ b/bin/create_all_pair_accounts
@@ -18,9 +18,10 @@ begin
   end
   print "(c)ontinue or (A)bort?: "
   if gets.strip =~ /^c(ontinue)?$/i
-    users.each do |u|
-      LsPair::LocalUser.new(u).provision
-      puts "Account provisioned for #{u}."
+    users.each do |username|
+      u = LsPair::LocalUser.new(username)
+      u.provision
+      puts "Account provisioned for #{username}."
     end
   end
 rescue LsPair::Exception => e

--- a/bin/create_pair_account
+++ b/bin/create_pair_account
@@ -13,11 +13,17 @@ def prompt_for_username
   gets.strip
 end
 
-username = ARGV[0] || prompt_for_username
+def prompt_for_wemux_default_mode
+  print "Enter the default wemux mode to use ('mirror', 'pair', or 'rogue' (default 'pair'): "
+  gets.strip
+end
+
+username        = ARGV[0] || prompt_for_username
+auto_wemux_mode = ARGV[1] || prompt_for_wemux_default_mode
 
 begin
   u = LsPair::LocalUser.new(username)
-  u.provision
+  u.provision(auto_wemux_mode)
 rescue LsPair::Exception => e
   puts e.message
 end

--- a/bin/create_pair_account
+++ b/bin/create_pair_account
@@ -16,7 +16,8 @@ end
 username = ARGV[0] || prompt_for_username
 
 begin
-  LsPair::LocalUser.new(username).provision
+  u = LsPair::LocalUser.new(username)
+  u.provision
 rescue LsPair::Exception => e
   puts e.message
 end

--- a/lib/install_helpers.rb
+++ b/lib/install_helpers.rb
@@ -48,11 +48,13 @@ end
 
 # Symlink our tmux configuration file into the user's home directory
 def symlink_tmux_conf_into_home
-  tmux_conf = Paths.home + '.tmux.conf'
-  if File.exist?(tmux_conf) && !File.symlink?(tmux_conf)
-    announce "Unable to symlink tmux.conf into your home directory.  (Apparently you've already got one.)"
+  tmux_conf       = Paths.home + '.tmux.conf'
+  tmux_conf_local = Paths.home + '.tmux.conf.local'
+  if real_file_exists?(tmux_conf) || real_file_exists?(tmux_conf_local)
+    announce "You already have a .tmux.conf and/or .tmux.conf.local file.  Skipping the part where we symlink those..."
   else
-    FileUtils.ln_sf Paths.root + 'tmux.conf', tmux_conf
+    FileUtils.ln_sf Paths.root + 'tmux.conf',       tmux_conf
+    FileUtils.ln_sf Paths.root + 'tmux.conf.local', tmux_conf_local
   end
 end
 
@@ -101,4 +103,8 @@ def toggle_vim_config
     FileUtils.ln_sf Paths.vimconfig + "vim", dot_vim
     FileUtils.ln_sf Paths.vimconfig + "vimrc", dot_vimrc
   end
+end
+
+def real_file_exists?(path)
+  File.exist?(path) && !File.symlink?(path)
 end

--- a/lib/ls_pair/local_user.rb
+++ b/lib/ls_pair/local_user.rb
@@ -1,6 +1,7 @@
 require 'ls_pair/directory_service'
 require 'ls_pair/filesystem'
 require 'ls_pair/ssh_keys'
+require 'ls_pair/wemux_command'
 
 module LsPair
   class LocalUser
@@ -9,11 +10,12 @@ module LsPair
       @username = username
     end
 
-    def provision
+    def provision(auto_wemux_mode = "pair")
       ensure_ssh_key_exists
       ensure_user_exists
       set_up_ssh_dir
       set_home_dir_permissions
+      set_auto_wemux_command auto_wemux_mode
     rescue LsPair::SshKeys::NoPublicKeyForUser => e
       puts e.message
     end
@@ -30,6 +32,10 @@ module LsPair
 
     def ssh_keys
       @options[:ssh_keys] || SshKeys.new
+    end
+
+    def wemux_command
+      @options[:wemux_command] || WemuxCommand.new
     end
 
     def home_dir
@@ -63,6 +69,14 @@ module LsPair
     def set_home_dir_permissions
       filesystem.chmod(0755, home_dir)
       filesystem.chown_R(@username, 'staff', home_dir)
+    end
+
+    def set_auto_wemux_command(mode)
+      wemux_command.set_auto_wemux_command(
+        mode,
+        filesystem: filesystem,
+        home_dir:   home_dir
+      )
     end
   end
 end

--- a/lib/ls_pair/wemux_command.rb
+++ b/lib/ls_pair/wemux_command.rb
@@ -1,0 +1,23 @@
+require 'ls_pair/exception'
+
+module LsPair
+  class WemuxCommand
+    class InvalidOption < LsPair::Exception
+    end
+
+    VALID_MODES = %w[ mirror pair rogue ]
+    def set_auto_wemux_command(mode, filesystem:, home_dir:)
+      mode = "pair" if mode.to_s =~ /^\s*$/
+
+      unless VALID_MODES.include?(mode)
+        raise InvalidOption, "sorry, wemux doesn't know what '#{mode}' means"
+      end
+
+      filesystem.create_file(
+        "#{home_dir}/.bash_profile", # path
+        "wemux #{mode} ; exit",      # content
+      )
+    end
+
+  end
+end

--- a/tmux.conf
+++ b/tmux.conf
@@ -90,27 +90,19 @@ bind m command-prompt -p "move window to:"  "move-window -t '%%'"
 set -g default-terminal "screen-256color"
 
 # Status bar
-set -g status-fg white
-set -g status-bg "#333333"
+set -g status-style bg="#333333",fg=white
 
 # Window list
-setw -g window-status-fg green
-setw -g window-status-bg default
-setw -g window-status-attr dim
-setw -g window-status-current-fg green
-setw -g window-status-current-bg white
-setw -g window-status-current-attr bright
+setw -g window-status-style bg="#333333",fg=green
+setw -g window-status-current-style bg=brightgreen,fg=black
+setw -g window-status-activity-style bg=brightblue,fg=black
 
 # Pane borders
-set -g pane-border-fg green
-set -g pane-border-bg black
-set -g pane-active-border-fg green
-set -g pane-active-border-bg yellow
+set -g pane-border-style bg=black,fg=green
+set -g pane-active-border-style bg=yellow,fg=green
 
 # Command line
-set -g message-fg white
-set -g message-bg black
-set -g message-attr bright
+set -g message-style bright,bg=black,fg=white
 
 # Status Bar Items
 set -g status-utf8 on

--- a/tmux.conf
+++ b/tmux.conf
@@ -118,5 +118,5 @@ set -g visual-activity on
 
 
 
-##### Local Settings #####
-source-file ~/.tmux.conf.local
+##### Local settings (if any) #####
+source-file -q ~/.tmux.conf.local

--- a/tmux.conf.local
+++ b/tmux.conf.local
@@ -1,0 +1,5 @@
+# This is where you can put custom tmux config commands that you don't
+# necessarily want to be part of the base config provided by ls-pair.
+
+# For example, if you prefer 0-based indexing, uncomment the following:
+# set -g base-index 0


### PR DESCRIPTION
I've walked a few people through installing ls-pair recently, and was noticing that they were getting a bunch of errors when launching wemux.  Most of them were because tmux changed the syntax of commands used to customize the display, and one was present because we were trying to source a `~/.tmux.conf.local` file that might not have been there.  This PR fixes those issues, on the off chance that anyone still at LS is even paying attention to this repo... :)